### PR TITLE
Python Warnings

### DIFF
--- a/APIv2/python/drivetest.py
+++ b/APIv2/python/drivetest.py
@@ -224,7 +224,7 @@ class App:
         self.row_count = 0
         distinctPoints = []
         for f in self.args.data_files:
-            with open(f, 'rU') as fp:
+            with open(f, 'r') as fp:
                 self.csv_data = csv.DictReader(fp)
 
                 self.csv_rows = [row for row in self.csv_data]

--- a/APIv2/python/requirements.txt
+++ b/APIv2/python/requirements.txt
@@ -1,4 +1,3 @@
 pyinstaller
 requests
 pystache
-pprint


### PR DESCRIPTION
Small fixes which resolve a couple of issues.

`pprint` is a [standard library](https://docs.python.org/3.8/library/pprint.html) included in Python3. Attempting to install from the `requirements.txt` throws an error.

```
ERROR: Could not find a version that satisfies the requirement pprint (from -r requirements.txt (line 4)) (from versions: none)
ERROR: No matching distribution found for pprint (from -r requirements.txt (line 4))
```

`U` mode for `open` is deprecated and is [assumed by default](https://docs.python.org/3/library/functions.html#open).

```
drivetest.py:227: DeprecationWarning: 'U' mode is deprecated
  with open(f, 'rU') as fp:
```