### PR TITLE
Remove `kmzppa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CloudRF API Clients Changelog
 
+## 2025-03-10
+
+- Removed `kmzppa` as an option when running `area` requests.
+
 ## 2024-10-16
 
 - Noise import client improved.

--- a/python/archived/area.py
+++ b/python/archived/area.py
@@ -16,7 +16,7 @@ class CloudRFArea(CloudRFAPITemplated):
 
     endpoint = '/area/'
     api_id = 'area'
-    file_types = ['kmz', 'kml', 'kmzppa', 'shp', 'tiff', 'url', 'html']
+    file_types = ['kmz', 'kml', 'shp', 'tiff', 'url', 'html']
 
     def download(self, select=None):
         select = self.file_types if select is None else select

--- a/python/archived/cloudrf.py
+++ b/python/archived/cloudrf.py
@@ -140,12 +140,6 @@ class CloudRFAPI:
 
         filepath = Path(self.download_dir) / filename
 
-        # kmzppa files have the same filename as kmz file.
-        # This complements the filename
-        if fmt == 'kmzppa':
-            bare_name = filepath.with_suffix('')
-            filepath = bare_name.with_name(f'{bare_name.name}_ppa').with_suffix('.kmz')
-
         print(f'saving {str(filepath)}')
         with open(filepath, 'wb') as fp:
             fp.write(req.content)


### PR DESCRIPTION
# Pull Request for CloudRF API Clients


## Checklist

- [x] I have merged the `master` branch into my working branch.
- [x] I have updated the `CHANGELOG.md` file with a brief overview of the change.

## Description

Removes `kmzppa` from `area` requests.