### PR TITLE
`path` PNG check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve error handling when using the auto-calibration script.
 - Fix validation error with default execution of auto-calibration script.
 - Fixed issue with `interference` Slippy Map demo hitting rate limit when working against CloudRF production API.
+- Fix streaming files that do no return a HTTP 200.
 
 ## 2025-03-10
 

--- a/python/CloudRF.py
+++ b/python/CloudRF.py
@@ -436,6 +436,11 @@ class CloudRF:
     def __streamUrlToFile(self, requestUrl, savePath):
         response = requests.get(requestUrl, stream = True, verify = self.__arguments.strict_ssl)
 
+        if response.status_code != 200:
+            print('An HTTP %d error occurred when trying to retrieve your file (%s) from the CloudRF API. Skipping file download. Full response is listed below.' % (response.status_code, requestUrl))
+            print(response.text)
+            return
+
         # If we are retrieving a stream
         if response.headers.get('Content-Disposition'):
             # The file extension may be different on the server side, so we should use that by default


### PR DESCRIPTION
Adds in a handler when streaming URL to a file to check that the HTTP response code is `200`.